### PR TITLE
Fix customer app imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ Your `tailwind.config.ts` and `globals.css` are already set up to use the compon
 To use the components in your app, import them from the `ui` package.
 
 ```tsx
-import { Button } from "@workspace/ui/components/button"
+import { Button } from "@univdiam/ui/components/button"
 ```

--- a/apps/customer/src/index.css
+++ b/apps/customer/src/index.css
@@ -1,1 +1,1 @@
-@import "@univdiam/ui/src/styles/globals.css";
+@import "@univdiam/ui/styles/globals.css";

--- a/apps/customer/src/main.tsx
+++ b/apps/customer/src/main.tsx
@@ -2,7 +2,6 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
-import '@univdiam/ui/globals.css'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/apps/customer/tsconfig.json
+++ b/apps/customer/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@workspace/ui/*": ["../../packages/ui/src/*"]
+      "@univdiam/ui/*": ["../../packages/ui/src/*"]
     }
   },
   "include": ["src", "vite.config.ts"],


### PR DESCRIPTION
## Summary
- fix README example path
- update UI imports for Vite
- clean up main entry
- align tsconfig paths

## Testing
- `pnpm exec tsc -p apps/customer/tsconfig.app.json`
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm build` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68482ba1df548326b325851f8cf02b62