### PR TITLE
Fix allowImportingTsExtensions error

### DIFF
--- a/packages/typescript-config/react-library.json
+++ b/packages/typescript-config/react-library.json
@@ -8,6 +8,7 @@
     "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
-    "moduleDetection": "force"
+    "moduleDetection": "force",
+    "noEmit": true
   }
 }


### PR DESCRIPTION
## Summary
- fix tsconfig so builds don't emit files when importing `.ts` extensions

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm build` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684830c2a8ec8326842fa6b1c6fca590