### PR TITLE
Fix dev server dependencies

### DIFF
--- a/apps/customer/vite.config.ts
+++ b/apps/customer/vite.config.ts
@@ -10,7 +10,8 @@ const dir = path.dirname(fileURLToPath(import.meta.url))
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    preserveSymlinks: true,
+    // follow symlinks so pnpm's linked dependencies are resolved correctly
+    preserveSymlinks: false,
     alias: {
       '@univdiam/ui': path.resolve(dir, '../../packages/ui/src'),
       "@": path.resolve(__dirname, "./src"),

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -9,6 +9,7 @@
     "./react-internal": "./react-internal.js"
   },
   "devDependencies": {
+    "@eslint/js": "^9.28.0",
     "@next/eslint-plugin-next": "^15.1.7",
     "@typescript-eslint/eslint-plugin": "^8.24.1",
     "@typescript-eslint/parser": "^8.24.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
 
   packages/eslint-config:
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.28.0
+        version: 9.28.0
       '@next/eslint-plugin-next':
         specifier: ^15.1.7
         version: 15.3.3


### PR DESCRIPTION
## Summary
- let Vite follow PNPM symlinks
- include `@eslint/js` so ESLint config resolves
- update lockfile for the new package

## Testing
- `pnpm run lint`
- `pnpm run dev --filter customer` (hit Ctrl+C after startup)

------
https://chatgpt.com/codex/tasks/task_e_68483ff969648326a9172a8acbd34211